### PR TITLE
test/exclude line starting with MemAvailable

### DIFF
--- a/tmux-mem-cpu-load.cpp
+++ b/tmux-mem-cpu-load.cpp
@@ -267,12 +267,21 @@ std::string mem_string( bool use_colors )
   for( unsigned int i = 0; i < 3; i++ )
     {
     getline( meminfo_file, mem_line );
-    line_start_pos = mem_line.find_first_of( ':' );
-    line_start_pos++;
-    line_end_pos = mem_line.find_first_of( 'k' );
-    iss.str( mem_line.substr( line_start_pos, line_end_pos - line_start_pos ) );
-    iss >> unused_mem;
-    used_mem -= unused_mem;
+    // accomodate MemAvailable potentially being in lines 2-4 of /proc/meminfo
+    // did this in a way to not break the original logic of the loop
+    if( mem_line.find("MemAvailable") == 0 )
+        {
+        i--;
+        }
+    else
+        {
+        line_start_pos = mem_line.find_first_of( ':' );
+        line_start_pos++;
+        line_end_pos = mem_line.find_first_of( 'k' );
+        iss.str( mem_line.substr( line_start_pos, line_end_pos - line_start_pos ) );
+        iss >> unused_mem;
+        used_mem -= unused_mem;
+        }
     }
   meminfo_file.close();
 


### PR DESCRIPTION
tested for line starting w/ 'MemAvailable' and exclude from used memory
calculation by simply decrementing the index variable by 1 and
proceeding

this is not the most robust way to deal with this as it still assumes that the correct entries are in the first 5 lines of /proc/meminfo, but this is a quick fix that has been tested on both the old (3.13.10-200) and new (3.14.2-200) kernels of Fedora 20

Closes #8
