### PR TITLE
Freebsd ramusage

### DIFF
--- a/freebsd/cpu.cc
+++ b/freebsd/cpu.cc
@@ -28,8 +28,13 @@
 
 float cpu_percentage( unsigned int cpu_usage_delay )
 {
-  int32_t load1[CPUSTATES];
-  int32_t load2[CPUSTATES];
+#if __x86_64__ || __ppc64__
+  u_int64_t load1[CPUSTATES];
+  u_int64_t load2[CPUSTATES];
+#else
+  u_int32_t load1[CPUSTATES];
+  u_int32_t load2[CPUSTATES];
+#endif
 
   GETSYSCTL( "kern.cp_time", load1 );
   usleep( cpu_usage_delay );


### PR DESCRIPTION
This is the same thing that we had on 64bit OpenBSD. And I've noticed that we had incorrect ram usages, which I fixed. See commit messages for details.

After this we can tag it and release. After release I'll try to get it running on NetBSD and maybe PC-BSD (which is FreeBSD based).