### PR TITLE
Dye the space between CPU util and load average.

### DIFF
--- a/common/main.cc
+++ b/common/main.cc
@@ -33,6 +33,21 @@
 #include "memory.h"
 #include "load.h"
 
+std::string space( size_t width, bool use_colors = false )
+{
+  std::ostringstream oss;
+  if( use_colors )
+  {
+    oss << "#[fg=brightwhite,bg=colour16]";
+  }
+  oss << std::string( width, ' ' );
+  if( use_colors )
+  {
+    oss << "#[fg=default,bg=default]";
+  }
+  return oss.str();
+}
+
 std::string cpu_string( unsigned int cpu_usage_delay, unsigned int graph_lines,
 	bool use_colors = false )
 {
@@ -155,9 +170,9 @@ int main( int argc, char** argv )
   }
 
   std::cout << mem_string( use_colors )
-    << cpu_string( cpu_usage_delay, graph_lines, use_colors ) << ' '
+    << cpu_string( cpu_usage_delay, graph_lines, use_colors )
+    << space( 2, use_colors )
     << load_string( use_colors );
 
   return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
I realize this could have been done on purpose, but the bright green space distracts me and I keep glancing down at it. Sending out a PR in case other folks experience the same.
Before:
![before](https://cloud.githubusercontent.com/assets/1587140/6655041/86d90df2-caa8-11e4-92be-25e2ec2bb519.png)
After:
![after](https://cloud.githubusercontent.com/assets/1587140/6655043/914dc2fa-caa8-11e4-87ea-e56c9daff3e5.png)

Tests succeed:
```
oozie@anonymous:~/src/tmux-mem-cpu-load$ make test
Running tests...
Test project /home/oozie/src/tmux-mem-cpu-load
    Start 1: usage
1/8 Test #1: usage ............................   Passed    0.00 sec
    Start 2: no_arguments
2/8 Test #2: no_arguments .....................   Passed    0.99 sec
    Start 3: custom_interval
3/8 Test #3: custom_interval ..................   Passed    2.99 sec
    Start 4: no_cpu_graph
4/8 Test #4: no_cpu_graph .....................   Passed    0.99 sec
    Start 5: colors
5/8 Test #5: colors ...........................   Passed    0.99 sec
    Start 6: invalid_status_interval
6/8 Test #6: invalid_status_interval ..........   Passed    0.00 sec
    Start 7: invalid_graph_lines
7/8 Test #7: invalid_graph_lines ..............   Passed    0.00 sec
    Start 8: old_option_specification
8/8 Test #8: old_option_specification .........   Passed    0.00 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) =   6.00 sec
```
