### PR TITLE
Don't print trailing whitespace for last element

### DIFF
--- a/common/load.cc
+++ b/common/load.cc
@@ -61,7 +61,15 @@ std::string load_string( bool use_colors = false )
     {
       // Round to nearest, make sure this is only a 0.00 value not a 0.0000
       float avg = floorf( static_cast<float>( averages[i] ) * 100 + 0.5 ) / 100;
-      ss << avg << " ";
+      // Don't print trailing whitespace for last element
+      if ( i == nelem-1 )
+      {
+        ss << avg;
+      }
+      else
+      {
+        ss << avg << " ";
+      }
     }
 
     if( use_colors )


### PR DESCRIPTION
I didn't like the fact that there was an unconditional whitespace after the load string which wouldn't look nice. If people want to retain the old behavior they can simple add an extra space in their `tmux.conf`.