### PR TITLE
Allow Easy Installation Via Antigen

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Install
   make install
   logout
 
-Build and Install Using [Antigen](https:/github.com/zsh-users/antigen)
+Build and Install Using [Antigen](https://github.com/zsh-users/antigen)
 --------
 
 Include the bundle in your ``.zshrc``

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,10 @@ Install
   make install
   logout
 
+Build and Install Using [Antigen](https:/github.com/zsh-users/antigen)
+--------
+Include the bundle in your ``.zshrc``
+``antigen bundle thewtex/tmux-mem-cpu-load``
 
 Configuring tmux_
 =================

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Install
 Build and Install Using [Antigen](https://github.com/zsh-users/antigen "Antigen is a ZSH Package Manager")
 
 -------
+
 Include the bundle in your ``.zshrc``
 
 ``antigen bundle thewtex/tmux-mem-cpu-load``

--- a/README.rst
+++ b/README.rst
@@ -81,12 +81,14 @@ Install
   make install
   logout
 
-Build and Install Using `Antigen`
+Build and Install Using `Antigen`_
 -------
 
 Include the bundle in your ``.zshrc``
 
-  ``antigen bundle thewtex/tmux-mem-cpu-load``
+::
+
+  antigen bundle thewtex/tmux-mem-cpu-load
 
 Configuring tmux_
 =================

--- a/README.rst
+++ b/README.rst
@@ -81,13 +81,12 @@ Install
   make install
   logout
 
-Build and Install Using [Antigen](https://github.com/zsh-users/antigen "Antigen is a ZSH Package Manager")
-
+Build and Install Using `Antigen`
 -------
 
 Include the bundle in your ``.zshrc``
 
-``antigen bundle thewtex/tmux-mem-cpu-load``
+  ``antigen bundle thewtex/tmux-mem-cpu-load``
 
 Configuring tmux_
 =================
@@ -140,5 +139,6 @@ Contributions from:
 .. _tmux: http://tmux.sourceforge.net/
 .. _CMake: http://www.cmake.org
 .. _`project homepage`: http://github.com/thewtex/tmux-mem-cpu-load
+.. _`Antigen`: https://github.com/zsh-users/antigen
 .. _`terminals with 256 color support`: http://misc.flogisoft.com/bash/tip_colors_and_formatting#terminals_compatibility
 .. _`Pawel 'l0ner' Soltys` : http://l0ner.github.io/

--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,9 @@ Install
   make install
   logout
 
-Build and Install Using [Antigen](https://github.com/zsh-users/antigen)
---------
+Build and Install Using [Antigen](https://github.com/zsh-users/antigen "Antigen is a ZSH Package Manager")
 
+-------
 Include the bundle in your ``.zshrc``
 
 ``antigen bundle thewtex/tmux-mem-cpu-load``

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,9 @@ Install
 
 Build and Install Using [Antigen](https:/github.com/zsh-users/antigen)
 --------
+
 Include the bundle in your ``.zshrc``
+
 ``antigen bundle thewtex/tmux-mem-cpu-load``
 
 Configuring tmux_

--- a/tmux-mem-cpu-load.plugin.zsh
+++ b/tmux-mem-cpu-load.plugin.zsh
@@ -1,7 +1,10 @@
 # vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
 
-pushd ${0:a:h} #Pushd to the directory where this file is located.
-cmake .
-make
-sudo make install
-popd
+if [ ! -s /usr/local/bin/tmux-mem-cpu-load ];
+then
+  pushd ${0:a:h} #Pushd to the directory where this plugin is located.
+  cmake .
+  make
+  sudo make install
+  popd
+fi

--- a/tmux-mem-cpu-load.plugin.zsh
+++ b/tmux-mem-cpu-load.plugin.zsh
@@ -1,4 +1,19 @@
-# vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
+ # vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
+ #
+ # Copyright 2012 Matthew McCormick
+ # Copyright 2015 Pawel 'l0ner' Soltys
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
 
 if [ ! -s /usr/local/bin/tmux-mem-cpu-load ];
 then

--- a/tmux-mem-cpu-load.plugin.zsh
+++ b/tmux-mem-cpu-load.plugin.zsh
@@ -1,0 +1,7 @@
+# vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
+
+pushd ${0:a:h} #Pushd to the directory where this file is located.
+cmake .
+make
+sudo make install
+popd


### PR DESCRIPTION
This pull request allows a user to easily load this repo by using [Antigen](https://github.com/zsh-users/antigen), a zsh package manager.

The user includes this repo by writing `antigen bundle thewtex/tmux-mem-cpu-load` in their `.zshrc` file. Once the `.zshrc` has been resourced, Antigen clones the repo and executes `tmux-mem-cpu-load.plugin.zsh`, which then automates the build and install steps.