### PR TITLE
Added memory modes to show different memory calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,14 @@ if(BUILD_TESTING)
     COMMAND tmux-mem-cpu-load 2 8
     )
 
+  add_test(NAME memory_mode_free_memory
+    COMMAND tmux-mem-cpu-load -m 1
+    )
+
+  add_test(NAME memory_mode_used_percentage
+    COMMAND tmux-mem-cpu-load -m 2
+    )
+
   set_tests_properties(usage
     invalid_status_interval
     invalid_graph_lines

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ The full usage::
           Set how many lines should be drawn in a graph. Default: 10
   -m <value>, --mem-mode
           Set the memory presentation mode, 0 for used/total, 1 for free memory and 2 for percentage.
+          Currently supported only by OSX
           Default: 0
 
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,9 @@ The full usage::
           Set tmux status refresh interval in seconds. Default: 1 second
   -g <value>, --graph-lines <value>
           Set how many lines should be drawn in a graph. Default: 10
+  -m <value>, --mem-mode
+          Set the memory presentation mode, 0 for used/total, 1 for free memory and 2 for percentage.
+          Default: 0
 
 
 Authors

--- a/common/main.cc
+++ b/common/main.cc
@@ -93,6 +93,7 @@ int main( int argc, char** argv )
   unsigned cpu_usage_delay = 990000;
   short graph_lines = 10; // max 32767 should be enough
   bool use_colors = false;
+  int mem_mode = 0;
 
   static struct option long_options[] =
   {
@@ -109,7 +110,7 @@ int main( int argc, char** argv )
 
   int c;
   // while c != -1
-  while( (c = getopt_long( argc, argv, "hi:g:", long_options, NULL) ) != -1 )
+  while( (c = getopt_long( argc, argv, "hi:g:m:", long_options, NULL) ) != -1 )
   {
     switch( c )
     {
@@ -136,6 +137,14 @@ int main( int argc, char** argv )
           }
         graph_lines = atoi( optarg );
         break;
+      case 'm': // --mem-mode, -m
+        if( atoi( optarg ) < 0 )
+          {
+            std::cerr << "Memory mode argument must be zero or greater.\n";
+            return EXIT_FAILURE;
+          }
+        mem_mode = atoi( optarg );
+        break;
       case '?':
         // getopt_long prints error message automatically
         return EXIT_FAILURE;
@@ -154,7 +163,7 @@ int main( int argc, char** argv )
     return EXIT_FAILURE;
   }
 
-  std::cout << mem_string( use_colors )
+  std::cout << mem_string( use_colors, mem_mode )
     << cpu_string( cpu_usage_delay, graph_lines, use_colors )
     << load_string( use_colors );
 

--- a/common/main.cc
+++ b/common/main.cc
@@ -93,7 +93,7 @@ int main( int argc, char** argv )
   unsigned cpu_usage_delay = 990000;
   short graph_lines = 10; // max 32767 should be enough
   bool use_colors = false;
-  int mem_mode = 0;
+  int mem_mode = MEMORY_MODE_DEFAULT;
 
   static struct option long_options[] =
   {

--- a/common/memory.h
+++ b/common/memory.h
@@ -21,6 +21,6 @@
 
 #include <string>
 
-std::string mem_string( bool );
+std::string mem_string( bool, int );
 
 #endif

--- a/common/memory.h
+++ b/common/memory.h
@@ -16,6 +16,13 @@
  * limitations under the License.
  */
 
+enum
+{
+  MEMORY_MODE_DEFAULT,
+  MEMORY_MODE_FREE_MEMORY,
+  MEMORY_MODE_USAGE_PERCENTAGE
+};
+
 #ifndef MEMORY_H_
 #define MEMORY_H_
 

--- a/freebsd/memory.cc
+++ b/freebsd/memory.cc
@@ -29,7 +29,7 @@
 #include "luts.h"
 #include "conversions.h"
 
-std::string mem_string( bool use_colors = false )
+std::string mem_string( bool use_colors = false, int mode = 0 )
 {
   // These values are in bytes
   //u_int total;

--- a/linux/memory.cc
+++ b/linux/memory.cc
@@ -24,7 +24,7 @@
 #include "luts.h"
 #include "conversions.h"
 
-std::string mem_string( bool use_colors = false )
+std::string mem_string( bool use_colors = false, int mode = 0 )
 {
   using std::string;
   using std::ifstream;

--- a/netbsd/memory.cc
+++ b/netbsd/memory.cc
@@ -28,7 +28,7 @@
 #include "conversions.h"
 #include "memory.h"
 
-std::string mem_string( bool use_colors = false )
+std::string mem_string( bool use_colors = false, int mode = 0 )
 {
   std::ostringstream oss;
 

--- a/openbsd/memory.cc
+++ b/openbsd/memory.cc
@@ -47,7 +47,7 @@ static int pageshift;
 #endif
 #define pagesh(size) ((size) << pageshift)
 
-std::string mem_string( bool use_colors = false )
+std::string mem_string( bool use_colors = false, int mode = 0 )
 {
   std::ostringstream oss;
 

--- a/osx/memory.cc
+++ b/osx/memory.cc
@@ -25,13 +25,14 @@
 #include "luts.h"
 #include "conversions.h"
 
-std::string mem_string( bool use_colors )
+std::string mem_string( bool use_colors, int mode )
 {
   std::ostringstream oss;
 
   // These values are in bytes
   u_int64_t total_mem;
-  u_int64_t used_mem;
+  float used_mem;
+  float percentage_mem;
   //u_int64_t unused_mem;
 
   vm_size_t page_size;
@@ -51,17 +52,35 @@ std::string mem_string( bool use_colors )
   {
     //unused_mem = static_cast<u_int64_t>( vm_stats.free_count * page_size );
 
-    used_mem = static_cast<u_int64_t>(
+    used_mem = static_cast<float>(
         ( vm_stats.active_count + vm_stats.wire_count ) * page_size);
   }
 
   if( use_colors )
   {
-    oss << mem_lut[( 100 * used_mem ) / total_mem];
+    oss << mem_lut[( 100 * static_cast<u_int64_t>(used_mem) ) / total_mem];
   }
 
-  oss << convert_unit( used_mem, MEGABYTES ) << '/' 
-    << convert_unit( total_mem, MEGABYTES ) << "MB";
+
+  percentage_mem = static_cast<float>(used_mem) / static_cast<float>(total_mem) * 100.0;
+
+  oss.precision( 2 );
+  oss.setf( std::ios::fixed | std::ios::right );
+
+  if( mode == 0 ) {
+    oss << convert_unit( used_mem, MEGABYTES ) << '/' 
+      << convert_unit( total_mem, MEGABYTES ) << "MB";
+  } else if ( mode == 1 ) {
+    float free_mem = total_mem - used_mem;
+
+    if( free_mem < 1 ) {
+      oss << convert_unit( free_mem, MEGABYTES ) << "MB";
+    } else {
+      oss << convert_unit( free_mem, GIGABYTES ) << "GB";
+    }
+  } else {
+    oss << percentage_mem << '%';
+  }
 
   if( use_colors )
   {


### PR DESCRIPTION
Hi, 

I added an option --mem-mode to toggle which memory calculation to show:

0: default (used/total)
1: Free memory
2: Usage percentage

I haven't added the presentation in linux, netbsd and freebsd, however I added the required argument so it doesn't break; adding the new calculations should also be straight forward for anyone on those platforms.