### PR TITLE
Adding powerline support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 # detect system type
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   message(STATUS "Linux detected")
-  set(METER_SOURCES "linux/memory.cc" "linux/cpu.cc" "common/load.cc" "common/powerline.cc")
+  set(METER_SOURCES "linux/memory.cc" "linux/cpu.cc" "common/load.cc")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   message(STATUS "Darwin detected")
   set(METER_SOURCES "osx/memory.cc" "osx/cpu.cc" "common/load.cc")
@@ -80,7 +80,7 @@ else()
 endif()
 
 # set common source files
-set(COMMON_SOURCES "common/main.cc" "common/memory.cc" "common/graph.cc")
+set(COMMON_SOURCES "common/main.cc" "common/memory.cc" "common/graph.cc""common/powerline.cc")
 
 # add binary tree so we find version.h
 include_directories("${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 # detect system type
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   message(STATUS "Linux detected")
-  set(METER_SOURCES "linux/memory.cc" "linux/cpu.cc" "common/load.cc")
+  set(METER_SOURCES "linux/memory.cc" "linux/cpu.cc" "common/load.cc" "common/powerline.cc")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   message(STATUS "Darwin detected")
   set(METER_SOURCES "osx/memory.cc" "osx/cpu.cc" "common/load.cc")
@@ -109,6 +109,10 @@ if(BUILD_TESTING)
 
   add_test(NAME colors
     COMMAND tmux-mem-cpu-load --colors
+    )
+
+  add_test(NAME powerline
+    COMMAND tmux-mem-cpu-load --powerline
     )
 
   add_test(NAME invalid_status_interval

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ else()
 endif()
 
 # set common source files
-set(COMMON_SOURCES "common/main.cc" "common/memory.cc" "common/graph.cc""common/powerline.cc")
+set(COMMON_SOURCES "common/main.cc" "common/memory.cc" "common/graph.cc" "common/powerline.cc")
 
 # add binary tree so we find version.h
 include_directories("${PROJECT_BINARY_DIR}")

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ The full usage::
            Prints this help message
   --colors
           Use tmux colors in output
-  --powerline
+  --powerline-right
           Use powerline symbols throughout the output, DO NOT reset background color at the end, enables --colors
   -i <value>, --interval <value>
           Set tmux status refresh interval in seconds. Default: 1 second

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,8 @@ The full usage::
            Prints this help message
   --colors
           Use tmux colors in output
+  --powerline
+          Use powerline symbols throughout the output, DO NOT reset background color at the end, enables --colors
   -i <value>, --interval <value>
           Set tmux status refresh interval in seconds. Default: 1 second
   -g <value>, --graph-lines <value>

--- a/common/load.cc
+++ b/common/load.cc
@@ -77,10 +77,14 @@ std::string load_string( bool use_colors, bool use_powerline )
 
     if( use_colors )
     {
-      if(use_powerline)
+      if( use_powerline )
+      {
         ss << ' ';
+      }
       else
+      {
         ss << "#[fg=default,bg=default]";
+      }
     }
   }
 

--- a/common/load.cc
+++ b/common/load.cc
@@ -30,10 +30,12 @@
 #include "load.h"
 #include "luts.h"
 
+#include "powerline.h"
+
 // Load Averages
-std::string load_string( bool use_colors = false )
+std::string load_string( bool use_colors, bool use_powerline )
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   // Get only 3 load averages
   const int nelem = 3;
   double averages[nelem];
@@ -54,7 +56,7 @@ std::string load_string( bool use_colors = false )
       {
         load_percent = 100;
       }
-      ss << load_lut[load_percent];
+      powerline(ss,  load_lut[load_percent], use_powerline);
     }
 
     ss << ' ';
@@ -75,7 +77,10 @@ std::string load_string( bool use_colors = false )
 
     if( use_colors )
     {
-      ss << "#[fg=default,bg=default]";
+      if(use_powerline)
+        ss << ' ';
+      else
+        ss << "#[fg=default,bg=default]";
     }
   }
 

--- a/common/load.h
+++ b/common/load.h
@@ -21,6 +21,6 @@
 
 #include <string>
 
-std::string load_string( bool );
+std::string load_string( bool use_colors = false, bool use_powerline = false );
 
 #endif

--- a/common/main.cc
+++ b/common/main.cc
@@ -67,9 +67,13 @@ std::string cpu_string( unsigned int cpu_usage_delay, unsigned int graph_lines,
   if( use_colors )
   {
     if( use_powerline )
+    {
       oss << ' ';
+    }
     else
+    {
       oss << "#[fg=default,bg=default]";
+    }
   }
 
   return oss.str();
@@ -88,7 +92,7 @@ void print_help()
     << "-c, --colors\n"
     << "--colors\n"
     << "\tUse tmux colors in output\n"
-    << "-p, --powerline\n"
+    << "-p, --powerline-right\n"
     << "\tUse powerline symbols throughout the output, DO NOT reset background color at the end, enables --colors\n"
     << "-i <value>, --interval <value>\n"
     << "\tSet tmux status refresh interval in seconds. Default: 1 second\n"
@@ -115,7 +119,7 @@ int main( int argc, char** argv )
     // otherwise it's a value to set the variable *flag points to
     { "help", no_argument, NULL, 'h' },
     { "colors", no_argument, NULL, 'c' },
-    { "powerline", no_argument, NULL, 'p' },
+    { "powerline-right", no_argument, NULL, 'p' },
     { "interval", required_argument, NULL, 'i' },
     { "graph-lines", required_argument, NULL, 'g' },
     { "mem-mode", required_argument, NULL, 'm' },
@@ -135,7 +139,7 @@ int main( int argc, char** argv )
       case 'c': // --colors
         use_colors = true;
         break;
-      case 'p': // --powerline
+      case 'p': // --powerline-right
         use_colors = true;
         use_powerline = true;
         break;

--- a/common/memory.cc
+++ b/common/memory.cc
@@ -21,10 +21,12 @@
 #include "memory.h"
 #include "luts.h"
 #include "conversions.h"
+#include "powerline.h"
 
 std::string mem_string( const MemoryStatus & mem_status,
   MEMORY_MODE mode,
-  bool use_colors )
+  bool use_colors,
+  bool use_powerline )
 {
   std::ostringstream oss;
   // Change the percision for floats, for a pretty output
@@ -33,7 +35,8 @@ std::string mem_string( const MemoryStatus & mem_status,
 
   if( use_colors )
   {
-    oss << mem_lut[static_cast< unsigned int >((100 * mem_status.used_mem) / mem_status.total_mem)];
+    unsigned int color = static_cast< unsigned int >((100 * mem_status.used_mem) / mem_status.total_mem);
+    powerline(oss, mem_lut[color], use_powerline);
   }
 
   switch( mode )
@@ -70,7 +73,14 @@ std::string mem_string( const MemoryStatus & mem_status,
 
   if( use_colors )
   {
-    oss << "#[fg=default,bg=default]";
+    if( use_powerline )
+    {
+      oss << " ";
+    }
+    else
+    {
+      oss << "#[fg=default,bg=default]";
+    }
   }
 
   return oss.str();

--- a/common/memory.h
+++ b/common/memory.h
@@ -49,6 +49,7 @@ enum MEMORY_MODE
 
 std::string mem_string( const MemoryStatus & mem_status,
   MEMORY_MODE mode = MEMORY_MODE_DEFAULT,
-  bool use_colors = false );
+  bool use_colors = false,
+  bool use_powerline = false );
 
 #endif

--- a/common/powerline.cc
+++ b/common/powerline.cc
@@ -1,3 +1,21 @@
+/* vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
+ *
+ * Copyright 2012 Matthew McCormick
+ * Copyright 2016 Michał Goliński
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "powerline.h"
 
 #include <cstring>
@@ -18,10 +36,14 @@ const char * bg2fg(const char s[])
 
 void powerline(std::ostringstream &oss, const char s[], bool use_powerline)
 {
-    if (use_powerline)
-    oss << bg2fg(s)
-        << PWL_RIGHT_FILLED
-        << s << ' ';
+    if( use_powerline )
+    {
+        oss << bg2fg(s)
+            << PWL_RIGHT_FILLED
+            << s << ' ';
+    }
     else
+    {
         oss << s;
+    }
 }

--- a/common/powerline.cc
+++ b/common/powerline.cc
@@ -1,0 +1,27 @@
+#include "powerline.h"
+
+#include <cstring>
+#include <sstream>
+
+#define PWL_RIGHT_FILLED ""
+
+const char * bg2fg(const char s[])
+{
+  static char buf[40] = {0};
+  const char *substr = index(s, ',');
+  buf[0] = '#';
+  buf[1] = '[';
+  buf[2] = 'f';
+  strcpy(buf+3, substr+2);
+  return buf;
+}
+
+void powerline(std::ostringstream &oss, const char s[], bool use_powerline)
+{
+    if (use_powerline)
+    oss << bg2fg(s)
+        << PWL_RIGHT_FILLED
+        << s << ' ';
+    else
+        oss << s;
+}

--- a/common/powerline.h
+++ b/common/powerline.h
@@ -1,0 +1,8 @@
+#ifndef POWERLINE_H
+#define POWERLINE_H
+
+#include <sstream>
+
+void powerline(std::ostringstream &oss, const char s[], bool);
+
+#endif // POWERLINE_H

--- a/common/powerline.h
+++ b/common/powerline.h
@@ -1,3 +1,21 @@
+/* vim: tabstop=2 shiftwidth=2 expandtab textwidth=80 linebreak wrap
+ *
+ * Copyright 2012 Matthew McCormick
+ * Copyright 2016 Michał Goliński
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef POWERLINE_H
 #define POWERLINE_H
 


### PR DESCRIPTION
These changes allow the meter to be displayed with powerline symbols, i.e., special symbol characters looking like arrows, like in the screenshot below. Only left facing arrows for now.

![powerline](https://cloud.githubusercontent.com/assets/1556664/13564395/96d69380-e449-11e5-8d2b-285aafddf1da.png)
