### PR TITLE
Added error message printing to the tmux plugin.

### DIFF
--- a/tmux-mem-cpu-load.plugin.tmux
+++ b/tmux-mem-cpu-load.plugin.tmux
@@ -19,6 +19,14 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd $CURRENT_DIR #Pushd to the directory where this plugin is located.
-cmake .
-make
+
+# Attempt to rebuild the plugin and log any errors in the tmux display window.
+output=$(cmake . 2>&1) || tmux run-shell "echo \"'cmake $CURRENT_DIR' failed.
+$output
+\"" && exit 1
+
+output=$(make 2>&1) || tmux run-shell "echo \"tmux-mem-cpu-load failed to build.
+$output
+\"" && exit 1
+
 popd


### PR DESCRIPTION
Added output error messsages to the tmux plugin file so that if either
cmake or make fail, you can find out why.

For example, if cmake is missing, the output looks like this:

```
'cmake /usr/local/google/home/nhdaly/.tmux/plugins/tmux-mem-cpu-load' failed.
/usr/local/google/home/nhdaly/.tmux/plugins//tmux-mem-cpu-load/tmux-mem-cpu-load.plugin.tmux: line 23: cmake: command not found
```

If there is some error during make, the output looks like this:

```
tmux-mem-cpu-load failed to build.
make: <make output error message>
```


------------------------------

This exact issue came up because my friend didn't have cmake installed, but the current `.plugin.tmux` file fails silently.