### PR TITLE
openbsd: use actual number of cpus being used

### DIFF
--- a/openbsd/cpu.cc
+++ b/openbsd/cpu.cc
@@ -27,7 +27,7 @@
 uint8_t get_cpu_count()
 {
   int cpu_count = 1; // default to 1
-  int mib[2] = { CTL_HW, HW_NCPU };
+  int mib[2] = { CTL_HW, HW_NCPUONLINE };
   size_t len = sizeof( cpu_count );
 
   if( sysctl( mib, 2, &cpu_count, &len, NULL, 0 ) < 0 )


### PR DESCRIPTION
For a while now OpenBSD has the `hw.ncpuonline` sysctl node which represents the actual number of CPUs that are online rather than the number of CPUs/threads which are present in the system.