### PR TITLE
uint32_t get_cpu_count() : support >255 threads

### DIFF
--- a/common/cpu.h
+++ b/common/cpu.h
@@ -45,7 +45,7 @@
 #endif
 
 float cpu_percentage( unsigned );
-uint8_t get_cpu_count();
+uint32_t get_cpu_count();
 
 /** CPU percentage output mode.
  *

--- a/linux/cpu.cc
+++ b/linux/cpu.cc
@@ -23,7 +23,7 @@
 #include "cpu.h"
 #include "luts.h"
 
-uint8_t get_cpu_count()
+uint32_t get_cpu_count()
 {
   return sysconf( _SC_NPROCESSORS_ONLN );
 }

--- a/osx/cpu.cc
+++ b/osx/cpu.cc
@@ -21,7 +21,7 @@
 
 #include "cpu.h"
 
-uint8_t get_cpu_count()
+uint32_t get_cpu_count()
 {
   return sysconf( _SC_NPROCESSORS_ONLN );
 }

--- a/windows/cpu.cc
+++ b/windows/cpu.cc
@@ -31,9 +31,9 @@ static PDH_HCOUNTER cpuTotal;
 #include "cpu.h"
 #include "luts.h"
 
-uint8_t get_cpu_count()
+uint32_t get_cpu_count()
 {
-  return static_cast< uint8_t >( std::thread::hardware_concurrency() );
+  return static_cast< uint32_t >( std::thread::hardware_concurrency() );
 }
 
 float cpu_percentage( unsigned cpu_usage_delay )


### PR DESCRIPTION
My linux server has 256 threads and I noticed that it always gives 0.0% cpu usage if set "-t 1". Tracing back I found you use uint_8 type function which return 0 when thread number=256, so I changed it into uint_32. Bug fixed and it runs smoothly on linux, but I don't test it on windows or osx system.