### PR TITLE
consistent precision

### DIFF
--- a/common/load.cc
+++ b/common/load.cc
@@ -39,6 +39,8 @@ std::string load_string( bool use_colors,
   short num_averages )
 {
   std::ostringstream ss;
+  ss.setf( std::ios::fixed, std::ios::floatfield );
+  ss.precision( 2 );
   double averages[num_averages];
   // based on: opensource.apple.com/source/Libc/Libc-262/gen/getloadavg.c
 

--- a/common/main.cc
+++ b/common/main.cc
@@ -87,7 +87,10 @@ std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigne
     oss << "]";
   }
   oss.width( 5 );
-  oss << percentage * multiplier;
+  oss.setf( std::ios::fixed, std::ios::floatfield );
+  oss.precision( 1 );
+  oss.fill( ' ' );
+  oss << std::right << percentage * multiplier;
   oss << "%";
   if( use_colors )
   {


### PR DESCRIPTION
- Use consistent precision for load output
- Specify precision in CPU percent output
