### PR TITLE
Update version number to match latest release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.5)
 ### General Package stuff
 project(tmux-mem-cpu-load)
 set(tmux-mem-cpu-load_VERSION_MAJOR 3)
-set(tmux-mem-cpu-load_VERSION_MINOR 4)
+set(tmux-mem-cpu-load_VERSION_MINOR 6)
 set(tmux-mem-cpu-load_VERSION_PATCH 0)
 #Compute full version string
 set(tmux-mem-cpu-load_VERSION


### PR DESCRIPTION
I guess it wasn't updated for the release of version `3.6.0` back in March.