### PR TITLE
Fix log messages when attempting to rebuild the plugin, and detect if the binary already exists to trigger rebuild.

### DIFF
--- a/tmux-mem-cpu-load.plugin.tmux
+++ b/tmux-mem-cpu-load.plugin.tmux
@@ -21,12 +21,24 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $CURRENT_DIR #Pushd to the directory where this plugin is located.
 
 # Attempt to rebuild the plugin and log any errors in the tmux display window.
-if output=$(cmake . 2>&1); then tmux run-shell "echo \"'cmake $CURRENT_DIR' failed.
-$output
-\""; else exit 1; fi
+if output=$(cmake . 2>&1); then
+   tmux run-shell "echo \"'cmake $CURRENT_DIR' completed successfully.
+   \""
+else
+   tmux run-shell "echo \"'cmake $CURRENT_DIR' failed. Error logged below.
+   $output
+   \""
+   exit 1
+fi
 
-if output=$(make 2>&1); then tmux run-shell "echo \"tmux-mem-cpu-load failed to build.
-$output
-\""; else exit 1; fi
+if output=$(make 2>&1); then 
+   tmux run-shell "echo \"tmux-mem-cpu-load built successfully.
+   \""
+else
+   tmux run-shell "echo \"tmux-mem-cpu-load failed to build. Error logged below.
+   $output
+   \""
+   exit 1
+fi
 
 popd

--- a/tmux-mem-cpu-load.plugin.tmux
+++ b/tmux-mem-cpu-load.plugin.tmux
@@ -18,27 +18,32 @@
 # The directory where this plugin is located.
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-pushd $CURRENT_DIR #Pushd to the directory where this plugin is located.
+if [ ! -f $CURRENT_DIR/tmux-mem-cpu-load ] && ! $(builtin type -P "tmux-mem-cpu-load" &> /dev/null) ; then
+   tmux run-shell "echo \"tmux-mem-cpu-load not found. Attempting to build.
+   \""
 
-# Attempt to rebuild the plugin and log any errors in the tmux display window.
-if output=$(cmake . 2>&1); then
-   tmux run-shell "echo \"'cmake $CURRENT_DIR' completed successfully.
-   \""
-else
-   tmux run-shell "echo \"'cmake $CURRENT_DIR' failed. Error logged below.
-   $output
-   \""
-   exit 1
+   pushd $CURRENT_DIR #Pushd to the directory where this plugin is located.
+
+   # Attempt to rebuild the plugin and log any errors in the tmux display window.
+   if output=$(cmake . 2>&1); then
+      tmux run-shell "echo \"'cmake $CURRENT_DIR' completed successfully.
+      \""
+   else
+      tmux run-shell "echo \"'cmake $CURRENT_DIR' failed. Error logged below.
+      $output
+      \""
+      exit 1
+   fi
+
+   if output=$(make 2>&1); then 
+      tmux run-shell "echo \"tmux-mem-cpu-load built successfully.
+      \""
+   else
+      tmux run-shell "echo \"tmux-mem-cpu-load failed to build. Error logged below.
+      $output
+      \""
+      exit 1
+   fi
+   popd
 fi
 
-if output=$(make 2>&1); then 
-   tmux run-shell "echo \"tmux-mem-cpu-load built successfully.
-   \""
-else
-   tmux run-shell "echo \"tmux-mem-cpu-load failed to build. Error logged below.
-   $output
-   \""
-   exit 1
-fi
-
-popd


### PR DESCRIPTION
- Fix log messages when attempting to rebuild the plugin, as the previous messages were showing the incorrect output if `cmake` failed, or if `make` failed to execute. This allows for better user notification, especially when loading through Tmux Plugin Manager.
- Test to see if the binary is already in the same folder as the repo (this is the case when using TPM), or if the binary is already on the user's $PATH. If the binary is not found, then the binary is compiled when calling the `*.tmux` file because it is assumed that it is being called through TPM.

Before:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/2390633/219997256-b36d008a-b2cf-468d-84b8-998d9e29dcea.png">

After:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/2390633/219997285-7f3b562e-13e6-4fec-b905-367aea6c8430.png">
