### PR TITLE
Increase CPU percent width by 1 (fixes #81)

### DIFF
--- a/common/main.cc
+++ b/common/main.cc
@@ -86,7 +86,7 @@ std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigne
     oss << get_graph_by_percentage( unsigned( percentage ), graph_lines );
     oss << "]";
   }
-  oss.width( 5 );
+  oss.width( 6 );
   oss.setf( std::ios::fixed, std::ios::floatfield );
   oss.precision( 1 );
   oss.fill( ' ' );


### PR DESCRIPTION
CPU percent width is 5, which accommodates the maximum possible width (100.0). When it's at full width, though, the percent string runs right up against the item before it.

When the graph is enabled, running up against the graph just looks strange, but still readable
(`[   |||]100.0%`). With the graph disabled (`-g 0`) though, it runs into the memory widget, which makes both of them very difficult to read (`11/32GB100.0%`).

This commit adds one space to the CPU percent width. It offsets a non-pegged load by one, but it ensures there's always at least one space to separate the widgets.