### PR TITLE
Add option to display CPU graph as vertical bar chart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,8 +144,8 @@ The full usage::
           Use tmux colors in output
   -p, --powerline-left
 	  Use powerline left symbols throughout the output, enables --colors
-  -n, --nerd-graph
-	  Use NerdFont characters to render CPU graph as vertical bar chart
+  -v, --vertical-graph
+	  Use vertical bar chart for CPU graph
   -q, --powerline-right
 	  Use powerline right symbols throughout the output, enables --colors
   -i <value>, --interval <value>

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,8 @@ The full usage::
           Use tmux colors in output
   -p, --powerline-left
 	  Use powerline left symbols throughout the output, enables --colors
+  -n, --nerd-graph
+	  Use NerdFont characters to render CPU graph as vertical bar chart
   -q, --powerline-right
 	  Use powerline right symbols throughout the output, enables --colors
   -i <value>, --interval <value>

--- a/common/graph.cc
+++ b/common/graph.cc
@@ -61,7 +61,7 @@ std::string get_graph_by_value( unsigned value, unsigned max, unsigned len )
   return bars;
 }
 
-std::string get_graph_nerd( unsigned value )
+std::string get_graph_vert( unsigned value )
 {
   static const std::map<unsigned, std::string> graph_chars = {
     { 0, " " }, { 10, "▁" }, { 20, "▂" }, { 30, "▃" }, { 40, "▄" },

--- a/common/graph.cc
+++ b/common/graph.cc
@@ -18,10 +18,11 @@
 
 #include <string>
 #include <cstring>
+#include <map>
 
 #include "graph.h"
 
-std::string get_graph_by_percentage( unsigned value, unsigned len ) 
+std::string get_graph_by_percentage( unsigned value, unsigned len )
 {
   unsigned step = 0;
   std::string bars;
@@ -60,3 +61,20 @@ std::string get_graph_by_value( unsigned value, unsigned max, unsigned len )
   return bars;
 }
 
+std::string get_graph_nerd( unsigned value )
+{
+  static const std::map<unsigned, std::string> graph_chars = {
+    { 0, " " }, { 10, "▁" }, { 20, "▂" }, { 30, "▃" }, { 40, "▄" },
+    { 50, "▅" }, { 60, "▆" }, { 70, "▇" }, { 80, "█" }, { 90, "▲" }
+  };
+
+  for( auto it = graph_chars.rbegin(); it != graph_chars.rend(); ++it )
+  {
+    if( value >= it->first )
+    {
+      return it->second;
+    }
+  }
+
+  return " "; // default return in case value doesn't match map options
+}

--- a/common/graph.h
+++ b/common/graph.h
@@ -23,5 +23,6 @@
 
 std::string get_graph_by_percentage( unsigned, unsigned len = 10 );
 std::string get_graph_by_value( unsigned, unsigned, unsigned len = 10 );
+std::string get_graph_nerd( unsigned );
 
 #endif

--- a/common/graph.h
+++ b/common/graph.h
@@ -23,6 +23,6 @@
 
 std::string get_graph_by_percentage( unsigned, unsigned len = 10 );
 std::string get_graph_by_value( unsigned, unsigned, unsigned len = 10 );
-std::string get_graph_nerd( unsigned );
+std::string get_graph_vert( unsigned );
 
 #endif

--- a/common/main.cc
+++ b/common/main.cc
@@ -37,7 +37,7 @@
 
 std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigned int graph_lines,
     bool use_colors = false,
-    bool use_powerline_left = false, bool use_powerline_right = false, bool nerd_graph = false)
+    bool use_powerline_left = false, bool use_powerline_right = false, bool use_nerd_graph = false)
 {
 
   float percentage;
@@ -80,7 +80,7 @@ std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigne
     }
   }
 
-  if( nerd_graph )
+  if( use_nerd_graph )
   {
     oss << "▕";
     oss << get_graph_nerd( unsigned( percentage ) );
@@ -152,9 +152,9 @@ int main( int argc, char** argv )
   bool use_colors = false;
   bool use_powerline_left = false;
   bool use_powerline_right = false;
+  bool use_nerd_graph = false;
   MEMORY_MODE mem_mode = MEMORY_MODE_DEFAULT;
   CPU_MODE cpu_mode = CPU_MODE_DEFAULT;
-  bool nerd_graph = false;
 
   static struct option long_options[] =
   {
@@ -197,7 +197,7 @@ int main( int argc, char** argv )
         use_powerline_right = true;
         break;
       case 'n': // --nerd-graph
-        nerd_graph = true;
+        use_nerd_graph = true;
         break;
       case 'i': // --interval, -i
         if( atoi( optarg ) < 1 )
@@ -260,7 +260,7 @@ int main( int argc, char** argv )
   MemoryStatus memory_status;
   mem_status( memory_status );
   std::cout << mem_string( memory_status, mem_mode, use_colors, use_powerline_left, use_powerline_right )
-    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right, nerd_graph )
+    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right, use_nerd_graph )
     << load_string( use_colors, use_powerline_left, use_powerline_right, averages_count );
 
   std::cout << std::endl;

--- a/common/main.cc
+++ b/common/main.cc
@@ -129,7 +129,7 @@ void print_help()
     << "\tUse powerline left symbols throughout the output, enables --colors\n"
     << "-q, --powerline-right\n"
     << "\tUse powerline right symbols throughout the output, enables --colors\n"
-    << "-n, --vertical-graph\n"
+    << "-v, --vertical-graph\n"
     << "\tUse vertical bar chart for CPU graph\n"
     << "-i <value>, --interval <value>\n"
     << "\tSet tmux status refresh interval in seconds. Default: 1 second\n"

--- a/common/main.cc
+++ b/common/main.cc
@@ -37,7 +37,7 @@
 
 std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigned int graph_lines,
     bool use_colors = false,
-    bool use_powerline_left = false, bool use_powerline_right = false )
+    bool use_powerline_left = false, bool use_powerline_right = false, bool nerd_graph = false)
 {
 
   float percentage;
@@ -80,7 +80,13 @@ std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigne
     }
   }
 
-  if( graph_lines > 0)
+  if( nerd_graph )
+  {
+    oss << "▕";
+    oss << get_graph_nerd( unsigned( percentage ) );
+    oss << "▏";
+  }
+  else if( graph_lines > 0)
   {
     oss << " [";
     oss << get_graph_by_percentage( unsigned( percentage ), graph_lines );
@@ -123,6 +129,8 @@ void print_help()
     << "\tUse powerline left symbols throughout the output, enables --colors\n"
     << "-q, --powerline-right\n"
     << "\tUse powerline right symbols throughout the output, enables --colors\n"
+    << "-n, --nerd-graph\n"
+    << "\tUse NerdFont symbols to render CPU graph as vertical bar chart\n"
     << "-i <value>, --interval <value>\n"
     << "\tSet tmux status refresh interval in seconds. Default: 1 second\n"
     << "-g <value>, --graph-lines <value>\n"
@@ -146,6 +154,7 @@ int main( int argc, char** argv )
   bool use_powerline_right = false;
   MEMORY_MODE mem_mode = MEMORY_MODE_DEFAULT;
   CPU_MODE cpu_mode = CPU_MODE_DEFAULT;
+  bool nerd_graph = false;
 
   static struct option long_options[] =
   {
@@ -157,6 +166,7 @@ int main( int argc, char** argv )
     { "colors", no_argument, NULL, 'c' },
     { "powerline-left", no_argument, NULL, 'p' },
     { "powerline-right", no_argument, NULL, 'q' },
+    { "nerd-graph", no_argument, NULL, 'n' },
     { "interval", required_argument, NULL, 'i' },
     { "graph-lines", required_argument, NULL, 'g' },
     { "mem-mode", required_argument, NULL, 'm' },
@@ -167,7 +177,7 @@ int main( int argc, char** argv )
 
   int c;
   // while c != -1
-  while( (c = getopt_long( argc, argv, "hi:cpqg:m:a:t:", long_options, NULL) ) != -1 )
+  while( (c = getopt_long( argc, argv, "hi:cpqng:m:a:t:", long_options, NULL) ) != -1 )
   {
     switch( c )
     {
@@ -185,6 +195,9 @@ int main( int argc, char** argv )
       case 'q': // --powerline-right
         use_colors = true;
         use_powerline_right = true;
+        break;
+      case 'n': // --nerd-graph
+        nerd_graph = true;
         break;
       case 'i': // --interval, -i
         if( atoi( optarg ) < 1 )
@@ -247,7 +260,7 @@ int main( int argc, char** argv )
   MemoryStatus memory_status;
   mem_status( memory_status );
   std::cout << mem_string( memory_status, mem_mode, use_colors, use_powerline_left, use_powerline_right )
-    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right )
+    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right, nerd_graph )
     << load_string( use_colors, use_powerline_left, use_powerline_right, averages_count );
 
   std::cout << std::endl;

--- a/common/main.cc
+++ b/common/main.cc
@@ -37,7 +37,7 @@
 
 std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigned int graph_lines,
     bool use_colors = false,
-    bool use_powerline_left = false, bool use_powerline_right = false, bool use_nerd_graph = false)
+    bool use_powerline_left = false, bool use_powerline_right = false, bool use_vert_graph = false)
 {
 
   float percentage;
@@ -80,10 +80,10 @@ std::string cpu_string( CPU_MODE cpu_mode, unsigned int cpu_usage_delay, unsigne
     }
   }
 
-  if( use_nerd_graph )
+  if( use_vert_graph )
   {
     oss << "▕";
-    oss << get_graph_nerd( unsigned( percentage ) );
+    oss << get_graph_vert( unsigned( percentage ) );
     oss << "▏";
   }
   else if( graph_lines > 0)
@@ -129,8 +129,8 @@ void print_help()
     << "\tUse powerline left symbols throughout the output, enables --colors\n"
     << "-q, --powerline-right\n"
     << "\tUse powerline right symbols throughout the output, enables --colors\n"
-    << "-n, --nerd-graph\n"
-    << "\tUse NerdFont symbols to render CPU graph as vertical bar chart\n"
+    << "-n, --vertical-graph\n"
+    << "\tUse vertical bar chart for CPU graph\n"
     << "-i <value>, --interval <value>\n"
     << "\tSet tmux status refresh interval in seconds. Default: 1 second\n"
     << "-g <value>, --graph-lines <value>\n"
@@ -152,7 +152,7 @@ int main( int argc, char** argv )
   bool use_colors = false;
   bool use_powerline_left = false;
   bool use_powerline_right = false;
-  bool use_nerd_graph = false;
+  bool use_vert_graph = false;
   MEMORY_MODE mem_mode = MEMORY_MODE_DEFAULT;
   CPU_MODE cpu_mode = CPU_MODE_DEFAULT;
 
@@ -166,7 +166,7 @@ int main( int argc, char** argv )
     { "colors", no_argument, NULL, 'c' },
     { "powerline-left", no_argument, NULL, 'p' },
     { "powerline-right", no_argument, NULL, 'q' },
-    { "nerd-graph", no_argument, NULL, 'n' },
+    { "vertical-graph", no_argument, NULL, 'v' },
     { "interval", required_argument, NULL, 'i' },
     { "graph-lines", required_argument, NULL, 'g' },
     { "mem-mode", required_argument, NULL, 'm' },
@@ -177,7 +177,7 @@ int main( int argc, char** argv )
 
   int c;
   // while c != -1
-  while( (c = getopt_long( argc, argv, "hi:cpqng:m:a:t:", long_options, NULL) ) != -1 )
+  while( (c = getopt_long( argc, argv, "hi:cpqvg:m:a:t:", long_options, NULL) ) != -1 )
   {
     switch( c )
     {
@@ -196,8 +196,8 @@ int main( int argc, char** argv )
         use_colors = true;
         use_powerline_right = true;
         break;
-      case 'n': // --nerd-graph
-        use_nerd_graph = true;
+      case 'v': // --vertical-graph
+        use_vert_graph = true;
         break;
       case 'i': // --interval, -i
         if( atoi( optarg ) < 1 )
@@ -260,7 +260,7 @@ int main( int argc, char** argv )
   MemoryStatus memory_status;
   mem_status( memory_status );
   std::cout << mem_string( memory_status, mem_mode, use_colors, use_powerline_left, use_powerline_right )
-    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right, use_nerd_graph )
+    << cpu_string( cpu_mode, cpu_usage_delay, graph_lines, use_colors, use_powerline_left, use_powerline_right, use_vert_graph )
     << load_string( use_colors, use_powerline_left, use_powerline_right, averages_count );
 
   std::cout << std::endl;


### PR DESCRIPTION
This commit adds the option to display the CPU usage graph as a vertical bar chart using NerdFont characters.

A triangle was selected to represent values of 90% or greater as it is a traditional symbol for fire.