### PR TITLE
Fix build with GCC 13

### DIFF
--- a/common/cpu.h
+++ b/common/cpu.h
@@ -19,6 +19,7 @@
 #ifndef CPU_H_
 #define CPU_H_
 
+#include <cstdint>
 #include <sys/types.h>
 
 #if defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895304