### PR TITLE
OpenBSD fixes

### DIFF
--- a/common/cpu.h
+++ b/common/cpu.h
@@ -28,12 +28,15 @@
   #define CP_IDLE 2
   #define CP_NICE 3
   #define CP_STATES 4
+#elif defined(__OpenBSD__)
+  #include <sys/sched.h>
+  #define CP_STATES CPUSTATES
 #else
   #define CP_USER   0
   #define CP_NICE   1
   #define CP_SYS    2
 
-  #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+  #if defined(__FreeBSD__) || defined(__NetBSD__)
     // *BSD or OSX
     #define CP_INTR   3
     #define CP_IDLE   4

--- a/openbsd/cpu.cc
+++ b/openbsd/cpu.cc
@@ -24,7 +24,7 @@
 #include "error.h"
 #include "cpu.h"
 
-uint8_t get_cpu_count()
+uint32_t get_cpu_count()
 {
   int cpu_count = 1; // default to 1
   int mib[2] = { CTL_HW, HW_NCPUONLINE };
@@ -35,7 +35,7 @@ uint8_t get_cpu_count()
     error( "sysctl: error getting cpu count" );
   }
 
-  return cpu_count;
+  return static_cast<uint32_t>( cpu_count );
 }
 
 float cpu_percentage( unsigned int cpu_usage_delay )
@@ -54,6 +54,8 @@ float cpu_percentage( unsigned int cpu_usage_delay )
   }
 
   usleep( cpu_usage_delay );
+
+  size = sizeof( load2 );
 
   // update cpu times
   if( sysctl( cpu_ctl, 2, &load2, &size, NULL, 0 ) < 0 )


### PR DESCRIPTION
You should probably look into doing the same for CP_* definitions on FreeBSD as well
as they are defined in sys/resource.h and there is really no point in re-defining them locally.