### PR TITLE
fix: build with `cmake --build .` instead of `make`

### DIFF
--- a/tmux-mem-cpu-load.plugin.tmux
+++ b/tmux-mem-cpu-load.plugin.tmux
@@ -35,7 +35,7 @@ if [ ! -f $CURRENT_DIR/tmux-mem-cpu-load ] && ! $(builtin type -P "tmux-mem-cpu-
       exit 1
    fi
 
-   if output=$(make 2>&1); then 
+   if output=$(cmake --build . 2>&1); then 
       tmux run-shell "echo \"tmux-mem-cpu-load built successfully.
       \""
    else


### PR DESCRIPTION
Someone might globally set `CMAKE_GENERATOR` to something other than `Unix Makefiles` (e.g., `Ninja`), and `make` will fail under such circumstances.