### PR TITLE
Fix invalid graph-lines test option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(BUILD_TESTING)
     )
 
   add_test(NAME invalid_graph_lines
-    COMMAND tmux-mem-cpu-load --graph_lines -2
+    COMMAND tmux-mem-cpu-load --graph-lines -2
     )
 
   add_test(NAME old_option_specification


### PR DESCRIPTION
Fixes the invalid_graph_lines CTest case to use the supported long option spelling, --graph-lines, instead of --graph_lines.
Previously, the test still passed because it was marked `WILL_FAIL`, but it was failing due to an unknown option rather than the intended graph-lines validation path.