### PR TITLE
Use unique release artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
       - name: "💾 save binaries"
         uses: actions/upload-artifact@v7
         with:
-          name: bin-artifact
+          name: bin-artifact-${{ matrix.arch_name }}
           path: tmux-mem-cpu-load-${{ matrix.arch_name }}.tar.xz
-          retention-days: 1        
+          retention-days: 1
   release:
     name: release
     runs-on: ubuntu-latest
@@ -47,7 +47,8 @@ jobs:
       - name: get artifact
         uses: actions/download-artifact@v8
         with:
-          name: bin-artifact
+          pattern: bin-artifact-*
+          merge-multiple: true
           path: .
       - name: "✅ checksum"
         run: find . -maxdepth 1 -name "*.tar.xz" | xargs sha256sum > checksum_all.sha256


### PR DESCRIPTION
Use unique artifact names for each release matrix build.

`actions/upload-artifact@v4+` does not support multiple jobs uploading to the same artifact name. The release workflow currently uploads every architecture as `bin-artifact`, which can cause artifact conflict errors in matrix builds.

This changes each upload to use the architecture name, then downloads all release artifacts with a pattern and `merge-multiple: true`.

