### PR TITLE
Handle empty powerline direction

### DIFF
--- a/common/powerline.cc
+++ b/common/powerline.cc
@@ -74,6 +74,8 @@ void powerline_char( std::ostringstream & oss, const char dynamic_color[],
   sprintf(write_color, "%d", static_color);
   switch( direction )
   {
+    case NONE:
+    break;
     case POWERLINE_LEFT:
       if ( eol )
       {


### PR DESCRIPTION
Handle the `NONE` value explicitly in `powerline_char()`.

This fixes a `-Wswitch` warning from stricter compiler builds, where `POWERLINE_DIRECTION::NONE` was not handled even though the function accepts the full enum.