### PR TITLE
Avoid variable length load average array

### DIFF
--- a/common/load.cc
+++ b/common/load.cc
@@ -42,14 +42,15 @@ std::string load_string( bool use_colors,
   std::ostringstream ss;
   ss.setf( std::ios::fixed, std::ios::floatfield );
   ss.precision( 2 );
-  double averages[num_averages];
-  // based on: opensource.apple.com/source/Libc/Libc-262/gen/getloadavg.c
 
   if( num_averages <= 0 || num_averages > 3)
   {
     ss << (char) 0;
     return ss.str();
   }
+
+  double averages[3];
+  // based on: opensource.apple.com/source/Libc/Libc-262/gen/getloadavg.c
 
   if( getloadavg( averages, num_averages ) < 0 )
   {


### PR DESCRIPTION
Avoid using a variable-length array in `load_string()`.

The project is built as C++11, but `double averages[num_averages]` relies on a compiler extension and triggers `-Wvla`. This also moved the array declaration after the existing `num_averages` validation, so invalid values such as `0` return before any array is declared.